### PR TITLE
Refactor search routes to APIRouter

### DIFF
--- a/api/routes/search.py
+++ b/api/routes/search.py
@@ -1,24 +1,35 @@
-# api/routes/search.py
-@app.route('/api/search')
-def search_jobs():
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/api/search")
+async def search_jobs():
     """Universal search endpoint"""
+    pass
 
 
-@app.route('/api/careers/<category>')
-def explore_careers():
+@router.get("/api/careers/{category}")
+async def explore_careers(category: str):
     """Explore careers by category"""
+    pass
 
 
-@app.route('/api/recommendations/student')
-def student_recommendations():
+@router.get("/api/recommendations/student")
+async def student_recommendations():
     """Career recommendations for students"""
+    pass
 
 
-@app.route('/api/recommendations/graduate')
-def graduate_recommendations():
+@router.get("/api/recommendations/graduate")
+async def graduate_recommendations():
     """Job recommendations for graduates"""
+    pass
 
 
-@app.route('/api/recommendations/professional')
-def professional_recommendations():
+@router.get("/api/recommendations/professional")
+async def professional_recommendations():
     """Career advancement recommendations"""
+    pass
+
+__all__ = ["router"]


### PR DESCRIPTION
## Summary
- switch search route decorators to use `APIRouter`
- provide minimal endpoint bodies
- export router for integration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686d91cb10f0832ebd01320f8690a645